### PR TITLE
refactor: Use kopf for more reliable status update detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install -r requirements.txt
 
 COPY controller.py .
 
-CMD ["python", "controller.py"]
+CMD ["kopf", "run", "controller.py", "--standalone", "--all-namespaces"]

--- a/controller.py
+++ b/controller.py
@@ -1,42 +1,22 @@
 from os import environ
-from kubernetes import client, config, watch
+
+from kubernetes import client
+import kopf
 
 
-def handle_pod_event(client: client.CoreV1Api, event, dry_run):
-    pod = event["object"]
+@kopf.on.field("Pod", field="status.phase")
+def handle_phase_change(name, namespace, status, **_):
+    api = client.CoreV1Api()
 
-    if pod.status.phase != "Failed":
+    if status["phase"] != "Failed":
         return
 
-    if pod.status.reason != "Terminated":
+    if status["reason"] != "Terminated":
         return
 
     print(
         'Removing pod %s in namespace %s. Message was "%s"'
-        % (pod.metadata.name, pod.metadata.namespace, pod.status.message)
+        % (name, namespace, status["message"])
     )
 
-    if dry_run:
-        print("Dry run set - not continuing.")
-        return
-
-    client.delete_namespaced_pod(
-        name=pod.metadata.name, namespace=pod.metadata.namespace
-    )
-
-
-def main():
-    dry_run = environ.get("CONTROLLER_DRY_RUN")
-
-    config.load_incluster_config()
-
-    v1 = client.CoreV1Api()
-
-    w = watch.Watch()
-
-    for event in w.stream(v1.list_pod_for_all_namespaces):
-        handle_pod_event(v1, event, dry_run)
-
-
-if __name__ == "__main__":
-    main()
+    api.delete_namespaced_pod(name=name, namespace=namespace)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 kubernetes==26.1.0
+kopf==1.36.0


### PR DESCRIPTION
The controller keeps dying.

Use [`kopf`](https://kopf.readthedocs.io/en/stable/) instead in the hope that it is better at watching for changes.