### PR TITLE
fix: Correct permissions for kopf

### DIFF
--- a/deploy/service-account.yaml
+++ b/deploy/service-account.yaml
@@ -18,8 +18,10 @@ rules:
     resources:
       - pods
     verbs:
-      - watch
       - delete
+      - list
+      - patch
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
`kopf` needs permission to list pods.