### PR TITLE
fix: resolve memory leak by reusing Kubernetes API client

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -3,10 +3,12 @@ from os import environ
 from kubernetes import client
 import kopf
 
+# Create a single API client instance to reuse across all events
+api = client.CoreV1Api()
+
 
 @kopf.on.field("Pod", field="status.phase")
 def handle_phase_change(name, namespace, status, **_):
-    api = client.CoreV1Api()
 
     if status["phase"] != "Failed":
         return


### PR DESCRIPTION
## Summary
• Moved `CoreV1Api` client instantiation to module level to prevent creating new instances on every pod phase change event
• Eliminates memory leak caused by accumulating HTTP connection pools and associated resources
• Single API client instance is now reused across all events

## Test plan
- [ ] Deploy the controller and monitor memory usage over time with multiple pod failures
- [ ] Verify that memory usage remains stable instead of continuously growing

🤖 Generated with [Claude Code](https://claude.ai/code)